### PR TITLE
Fix escape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ doc/api/
 *.js.deps
 *.js.map
 .vscode/
+.idea/

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,5 @@
+include:
+  package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude: [test/**]

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,10 +45,11 @@ class MyHomePage extends StatelessWidget {
                 decoration: InputDecoration(hintText: 'Brazilian CPF'),
                 inputFormatters: [
                   TextInputMask(
-                      mask: '999.999.999-99',
-                      placeholder: '_',
-                      maxPlaceHolders: 11,
-                      reverse: false)
+                    mask: '999.999.999-99',
+                    placeholder: '_',
+                    maxPlaceHolders: 11,
+                    reverse: false,
+                  )
                 ],
               ),
             ),
@@ -69,8 +70,9 @@ class MyHomePage extends StatelessWidget {
                 decoration: InputDecoration(hintText: 'Multi Mask Phone'),
                 inputFormatters: [
                   TextInputMask(
-                      mask: ['(99) 9999 9999', '(99) 99999 9999'],
-                      reverse: false)
+                    mask: ['(99) 9999 9999', '(99) 99999 9999'],
+                    reverse: false,
+                  )
                 ],
               ),
             ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,5 @@
 name: easy_mask_example
 version: 0.0.1
-authors:
-  - "Danilo Coppi"
 
 description: TextInputMask ready to be used just passing a String patterned parameter.
 homepage: https://github.com/danilocoppi/flutter-textfiled-mask
@@ -10,8 +8,8 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  cupertino_icons: ^0.1.3
-  easy_mask: ^2.0.0
+  cupertino_icons: ^1.0.4
+  easy_mask: ^2.0.1
   # easy_mask:
   #     path: ../
   flutter:

--- a/lib/src/magic_mask.dart
+++ b/lib/src/magic_mask.dart
@@ -95,6 +95,7 @@ class MagicMask {
       String currentChar = mask[i];
       if (currentChar == '\\') {
         _tags.add({_type: _fixChar, _value: mask[i + 1]});
+        i++;
       } else if (currentChar == '*') {
         if (_lastMaskType() == _token) _tags.last[_type] = _multipleOpt;
       } else if (currentChar == '+') {

--- a/lib/src/magic_mask.dart
+++ b/lib/src/magic_mask.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-/// This class is used to make all hardwork of making and controll the users cursor.
-/// It should be used by TextInputMask, so you dont need to worry about it.
+/// This class is used to make all hardwork of making and control the users cursor.
+/// It should be used by TextInputMask, so you don't need to worry about it.
 /// If you want you can use it as String masker.
 class MagicMask {
   static const String _type = 'type';
@@ -12,7 +12,7 @@ class MagicMask {
   static const String _token = 'token';
   static const String _tokenOpt = 'optionalToken';
   static const String _multiple = 'multiple';
-  static const String _multipleOpt = 'multiple';
+  static const String _multipleOpt = 'multipleOpt';
 
   late bool _reverse;
   bool _overflow = false;
@@ -28,13 +28,13 @@ class MagicMask {
   late int _typedCharacter;
 
   List<Map<String, String>> _tags = [];
-  List<List<Map<String, String>>> _allTags = [];
+  final List<List<Map<String, String>>> _allTags = [];
   int _curTag = 0;
 
   MagicMask();
 
   MagicMask.buildMask(dynamic mask) {
-    if (mask != null) this.buildMaskTokens(mask);
+    if (mask != null) buildMaskTokens(mask);
   }
 
   String? _lastMaskType() => _tags.last[_type];
@@ -81,11 +81,13 @@ class MagicMask {
       _curTag += 1;
     }
 
-    _allTags.sort((maskA, maskB) => maskA.length > maskB.length
-        ? 1
-        : maskA.length == maskB.length
-            ? 0
-            : -1);
+    _allTags.sort(
+      (maskA, maskB) => maskA.length > maskB.length
+          ? 1
+          : maskA.length == maskB.length
+              ? 0
+              : -1,
+    );
   }
 
   void _processMask(String mask) {
@@ -121,22 +123,32 @@ class MagicMask {
       getAdvancedMaskedString(text, -1, '', 0);
 
   /// [text] is the string to be formatted
-  /// [maxLenght] is used to limit the maximum returned text. Set it as -1 to not limitate.
-  /// [placeholder] String character to be applyed as placeholder
+  /// [maxLenght] is used to limit the maximum returned text. Set it as -1 to not limited.
+  /// [placeholder] String character to be applied as placeholder
   /// [maxPlaceHolderCharacters] Numbers of times the placeholder could be counted. A typed character consumes a count.
   ///
   /// It returns a formatted String.
-  String getAdvancedMaskedString(String text, int maxLenght, String placeholder,
-      int maxPlaceHolderCharacters) {
-    return executeMasking(text, 0, false, maxLenght, placeholder,
-        maxPlaceHolderCharacters)['text'];
+  String getAdvancedMaskedString(
+    String text,
+    int maxLenght,
+    String placeholder,
+    int maxPlaceHolderCharacters,
+  ) {
+    return executeMasking(
+      text,
+      0,
+      false,
+      maxLenght,
+      placeholder,
+      maxPlaceHolderCharacters,
+    )['text'];
   }
 
   /// [text] is the mask to be formatter on mask.
   /// [cursorPosition] means the cursor position before masking.
-  /// [reverse] is used to define the diretion mask will be applyed.
-  /// [maxLenght] is used to limit the maximum returned text. Set it as -1 to not limitate.
-  /// [placeholder] String character to be applyed as placeholder
+  /// [reverse] is used to define the direction mask will be applied.
+  /// [maxLenght] is used to limit the maximum returned text. Set it as -1 to not limited.
+  /// [placeholder] String character to be applied as placeholder
   /// [maxPlaceHolderCharacters] Numbers of times the placeholder could be counted. A typed character consumes a count.
   ///
   /// It Return a JSON format to be used to create a TextEditingValue. Its format is:
@@ -155,8 +167,9 @@ class MagicMask {
       int maxLenght,
       String placeholder,
       int maxPlaceHolderCharacters) {
-    if (text == null || text.isEmpty || _tags.length == 0)
+    if (text == null || text.isEmpty || _tags.isEmpty) {
       return _buildResultJson('', 0, maxLenght);
+    }
     _reverse = reverse;
     _step = _reverse ? -1 : 1;
     _placeholder = placeholder;
@@ -171,7 +184,9 @@ class MagicMask {
       _extraChar = '';
       _overflow = false;
       _tagIndex = _reverse ? _tags.length - 1 : 0;
-      for (Map<String, String> tag in _tags) tag['readed'] = '';
+      for (Map<String, String> tag in _tags) {
+        tag['readed'] = '';
+      }
 
       String cleared = clearMask(text);
       cleared = _clearPlaceHolder(cleared);

--- a/lib/src/text_input_mask.dart
+++ b/lib/src/text_input_mask.dart
@@ -15,8 +15,8 @@ class TextInputMask extends TextInputFormatter {
 
   /// [mask] is the String or Array of Strings to be used as mask(s).
   /// [reverse] is a bool. When true it will mask on reverse mode, usually to be used on currency fields.
-  /// [maxLength] can be used to limit the maximum length. Leave it null or -1 to not limitate
-  /// [placeholder] is a string to be applyed on untyped characters.
+  /// [maxLength] can be used to limit the maximum length. Leave it null or -1 to not limited
+  /// [placeholder] is a string to be applied on untyped characters.
   /// [maxPlaceHolders] max times a placeholder is counted. Typed characters consumes the counter.
   /// ex placeholder as '0' with max=3 on a text like '3' with mask 9+.99 will be 0.03 not 000000.03
   ///
@@ -44,7 +44,7 @@ class TextInputMask extends TextInputFormatter {
   ///
   /// \! - Used to force print it, when it has at least 1 letter
   ///
-  /// When passing an array of String as mask, the first mask applyed is the shortest going to longest.
+  /// When passing an array of String as mask, the first mask applied is the shortest going to longest.
   /// It will apply the next mask (bigger one, only when the typed text overflow the previous mask)
   TextInputMask(
       {this.mask,
@@ -59,13 +59,16 @@ class TextInputMask extends TextInputFormatter {
   TextEditingValue formatEditUpdate(
       TextEditingValue oldValue, TextEditingValue newValue) {
     try {
-      return TextEditingValue.fromJSON(magicMask.executeMasking(
+      return TextEditingValue.fromJSON(
+        magicMask.executeMasking(
           newValue.text,
           newValue.selection.baseOffset,
           reverse,
           maxLength,
           placeholder,
-          maxPlaceHolders));
+          maxPlaceHolders,
+        ),
+      );
     } catch (e) {
       print(e);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,5 +14,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: 1.0.4
 
 

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -4,10 +4,10 @@ import 'package:flutter_test/flutter_test.dart';
 void main() async {
   test('Brazilian Cellphone', () {
     String baseMask = '\\+99? (99) 99999 - 9999?';
-    String basetest = '5519981234567';
+    String baseTest = '5519981234567';
     MagicMask mm = MagicMask();
     mm.buildMaskTokens(baseMask);
-    var result = mm.executeMasking(basetest, 3, false, -1, '', 0);
+    var result = mm.executeMasking(baseTest, 3, false, -1, '', 0);
     print(result);
     expect(result['text'], '+55 (19) 98123 - 4567');
     expect(result['selectionBase'], 6);
@@ -15,10 +15,10 @@ void main() async {
 
   test('Brazilian Personal Document', () {
     String baseMask = '999.999.999-99';
-    String basetest = '123123HUM12344';
+    String baseTest = '123123HUM12344';
     MagicMask mm = MagicMask();
     mm.buildMaskTokens(baseMask);
-    var result = mm.executeMasking(basetest, 4, false, -1, '', 0);
+    var result = mm.executeMasking(baseTest, 4, false, -1, '', 0);
     print(result);
     expect(result['text'], '123.123.123-44');
     expect(result['selectionBase'], 5);
@@ -26,10 +26,10 @@ void main() async {
 
   test('USA Celphone', () {
     String baseMask = '\\+1 (999) 999 99 99';
-    String basetest = '446667AAAAAA8899';
+    String baseTest = '446667AAAAAA8899';
     MagicMask mm = MagicMask();
     mm.buildMaskTokens(baseMask);
-    var result = mm.executeMasking(basetest, 4, false, -1, '', 0);
+    var result = mm.executeMasking(baseTest, 4, false, -1, '', 0);
     print(result);
     expect(result['text'], '+1 (446) 667 88 99');
     expect(result['selectionBase'], 10);
@@ -37,10 +37,10 @@ void main() async {
 
   test('Credit Card', () {
     String baseMask = '9999 9999 9999 9999';
-    String basetest = '1234555@#566667878';
+    String baseTest = '1234555@#566667878';
     MagicMask mm = MagicMask();
     mm.buildMaskTokens(baseMask);
-    var result = mm.executeMasking(basetest, 4, false, -1, '', 0);
+    var result = mm.executeMasking(baseTest, 4, false, -1, '', 0);
     print(result);
     expect(result['text'], '1234 5555 6666 7878');
     expect(result['selectionBase'], 4);
@@ -48,10 +48,10 @@ void main() async {
 
   test('Reversed Money without thousand separator comma', () {
     String baseMask = '\$! !9+.99';
-    String basetest = '1025065';
+    String baseTest = '1025065';
     MagicMask mm = MagicMask();
     mm.buildMaskTokens(baseMask);
-    var result = mm.executeMasking(basetest, 7, true, -1, '', 0);
+    var result = mm.executeMasking(baseTest, 7, true, -1, '', 0);
     print(result);
     expect(result['text'], '\$ 10250.65');
     expect(result['selectionBase'], 10);
@@ -59,10 +59,10 @@ void main() async {
 
   test('Reversed Money with thousand separator comma', () {
     String baseMask = '\$! !9+,999.99';
-    String basetest = '1025065A';
+    String baseTest = '1025065A';
     MagicMask mm = MagicMask();
     mm.buildMaskTokens(baseMask);
-    var result = mm.executeMasking(basetest, 7, true, -1, '', 0);
+    var result = mm.executeMasking(baseTest, 7, true, -1, '', 0);
     print(result);
     expect(result['text'], '\$ 10,250.65');
     expect(result['selectionBase'], 11);
@@ -70,19 +70,41 @@ void main() async {
 
   test('Custom Masks', () {
     String baseMask = '99 AA 999';
-    String basetest = '33xyz.@999';
+    String baseTest = '33xyz.@999';
     MagicMask mm = MagicMask();
     mm.buildMaskTokens(baseMask);
-    var result = mm.executeMasking(basetest, 7, false, -1, '', 0);
+    var result = mm.executeMasking(baseTest, 7, false, -1, '', 0);
     print(result);
     expect(result['text'], '33 xy 999');
     expect(result['selectionBase'], 5);
+  });
+
+  test('Escape Masks', () {
+    String baseMask = '\\9! \\A! AAAA';
+    String baseTest = 'Test';
+    MagicMask mm = MagicMask();
+    mm.buildMaskTokens(baseMask);
+    var result = mm.executeMasking(baseTest, 0, false, -1, '', 0);
+    print(result);
+    expect(result['text'], '9 A Test');
+    expect(result['selectionBase'], 0);
+  });
+
+  test('Escape Masks(Time Case)', () {
+    String baseMask = '99:99 !\\A!M!';
+    String baseTest = '12:30';
+    MagicMask mm = MagicMask();
+    mm.buildMaskTokens(baseMask);
+    var result = mm.executeMasking(baseTest, 0, false, -1, '', 0);
+    print(result);
+    expect(result['text'], '12:30 AM');
+    expect(result['selectionBase'], 0);
   });
 
   test('Simple text', () {
     String text = '432516565';
     MagicMask mask = MagicMask.buildMask('\\+99 (99) 99999-9999');
     var res = mask.getMaskedString(text);
-    print(res);
+    expect(res, '+43 (25) 16565');
   });
 }


### PR DESCRIPTION
* Fix issue when escaping special symbols like `9` or `A`
* Add linter and correct code style and typos

```yaml
easy_mask:
  git:
    url: https://github.com/TheSuperiorStanislav/flutter-textfield-mask
    ref: fix-escape
```

Closes #7 